### PR TITLE
map external ondisk varlena to unchanged datum

### DIFF
--- a/proto/pg_logicaldec.proto
+++ b/proto/pg_logicaldec.proto
@@ -25,6 +25,7 @@ message DatumMessage {
 		string datum_string = 8;
 		bytes datum_bytes = 9;
 		Point datum_point = 10;
+		bool datum_unchanged = 11;
 	}
 }
 

--- a/src/decoderbufs.c
+++ b/src/decoderbufs.c
@@ -608,8 +608,8 @@ static int tuple_to_tuple_msg(Decoderbufs__DatumMessage **tmsg,
     getTypeOutputInfo(attr->atttypid, &typoutput, &typisvarlena);
     if (!isnull) {
       if (typisvarlena && VARATT_IS_EXTERNAL_ONDISK(origval)) {
-        // TODO: Is there a way we can handle this?
-        elog(WARNING, "Not handling external on disk varlena at the moment.");
+        datum_msg.datum_unchanged = true;
+        datum_msg.datum_case = DECODERBUFS__DATUM_MESSAGE__DATUM_DATUM_UNCHANGED;
       } else if (!typisvarlena) {
         set_datum_value(&datum_msg, attr->atttypid, typoutput, origval);
       } else {

--- a/src/proto/pg_logicaldec.pb-c.c
+++ b/src/proto/pg_logicaldec.pb-c.c
@@ -187,7 +187,7 @@ const ProtobufCMessageDescriptor decoderbufs__point__descriptor =
   (ProtobufCMessageInit) decoderbufs__point__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor decoderbufs__datum_message__field_descriptors[10] =
+static const ProtobufCFieldDescriptor decoderbufs__datum_message__field_descriptors[11] =
 {
   {
     "column_name",
@@ -309,6 +309,18 @@ static const ProtobufCFieldDescriptor decoderbufs__datum_message__field_descript
     0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
+  {
+    "datum_unchanged",
+    11,
+    PROTOBUF_C_LABEL_OPTIONAL,
+    PROTOBUF_C_TYPE_BOOL,
+    offsetof(Decoderbufs__DatumMessage, datum_case),
+    offsetof(Decoderbufs__DatumMessage, datum_unchanged),
+    NULL,
+    NULL,
+    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,NULL,NULL    /* reserved1,reserved2, etc */
+  },
 };
 static const unsigned decoderbufs__datum_message__field_indices_by_name[] = {
   0,   /* field[0] = column_name */
@@ -321,11 +333,12 @@ static const unsigned decoderbufs__datum_message__field_indices_by_name[] = {
   3,   /* field[3] = datum_int64 */
   9,   /* field[9] = datum_point */
   7,   /* field[7] = datum_string */
+  10,   /* field[10] = datum_unchanged */
 };
 static const ProtobufCIntRange decoderbufs__datum_message__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 10 }
+  { 0, 11 }
 };
 const ProtobufCMessageDescriptor decoderbufs__datum_message__descriptor =
 {
@@ -335,7 +348,7 @@ const ProtobufCMessageDescriptor decoderbufs__datum_message__descriptor =
   "Decoderbufs__DatumMessage",
   "decoderbufs",
   sizeof(Decoderbufs__DatumMessage),
-  10,
+  11,
   decoderbufs__datum_message__field_descriptors,
   decoderbufs__datum_message__field_indices_by_name,
   1,  decoderbufs__datum_message__number_ranges,

--- a/src/proto/pg_logicaldec.pb-c.h
+++ b/src/proto/pg_logicaldec.pb-c.h
@@ -54,6 +54,7 @@ typedef enum {
   DECODERBUFS__DATUM_MESSAGE__DATUM_DATUM_STRING = 8,
   DECODERBUFS__DATUM_MESSAGE__DATUM_DATUM_BYTES = 9,
   DECODERBUFS__DATUM_MESSAGE__DATUM_DATUM_POINT = 10,
+  DECODERBUFS__DATUM_MESSAGE__DATUM_DATUM_UNCHANGED = 11,
 } Decoderbufs__DatumMessage__DatumCase;
 
 struct  _Decoderbufs__DatumMessage
@@ -72,6 +73,7 @@ struct  _Decoderbufs__DatumMessage
     char *datum_string;
     ProtobufCBinaryData datum_bytes;
     Decoderbufs__Point *datum_point;
+    protobuf_c_boolean datum_unchanged;
   };
 };
 #define DECODERBUFS__DATUM_MESSAGE__INIT \


### PR DESCRIPTION
This will allow DM to differentiate between actual null values, and those that were not included in the `RowMessage` due to external on disk values.