### PR TITLE
Skip pg_temp_* changes from replication

### DIFF
--- a/src/decoderbufs.c
+++ b/src/decoderbufs.c
@@ -644,6 +644,8 @@ static int tuple_to_tuple_msg(Decoderbufs__DatumMessage **tmsg,
   return skipped;
 }
 
+const char *PG_TEMP_PREFIX = "pg_temp_";
+  
 /* callback for individual changed tuples */
 static void pg_decode_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
                              Relation relation, ReorderBufferChange *change) {
@@ -655,6 +657,10 @@ static void pg_decode_change(LogicalDecodingContext *ctx, ReorderBufferTXN *txn,
   bool is_rel_non_selective;
   Decoderbufs__RowMessage rmsg = DECODERBUFS__ROW_MESSAGE__INIT;
   class_form = RelationGetForm(relation);
+
+  if (strncmp(PG_TEMP_PREFIX, NameStr(class_form->relname), strlen(PG_TEMP_PREFIX)) == 0) {
+    return;
+  }
 
   data = ctx->output_plugin_private;
 


### PR DESCRIPTION
## Explanation
p2q hangs after a pg_temp_XXX table is created by postgres after doing a migration such as the one that triggered the incident (see ticket).
The issue is easily reproducible in local env (see below).

Monitoring postgres during the migration, the wal_sender process starts to consume 99% CPU after a migration is triggered while p2q is active. After a certain period of time, ~2-4 hours of cpu time, before finishing to deliver all the changes in the new table (~8hours of cpu time for devel db), the wal_sender proc goes idle unexpectedly, and never exits or goes active again (left it an entire day, even stopped p2q and nothing). Mem (<0.5%) and cpu (0) usage during that phase were stable, so it's just holding a microbatch of changes that are not being sent for some reason.

The bug is an ongoing issue in postgres so it is a server-side bug and not related to the client (ie: p2q should not change).
However, the client could change the behavior to fix it (as it is doing now, while running in debug mode). If the client confirms messages at a slower rate, the wal_sender does not hang, but it is not efficient.

Moreover, "slower" depends on the environment:
In my m1 machine it behaves as it does in prod (debug solves the issue) but adding more records to the db beforehand (i.e: 3x amount of data in db:import) results in hang. In my linux machine the issue happens always (w or wout debug). So, we are lucky in prod for now 😄.

So the simplest solution here is to skip changes from temporal tables directly in decoderbufs.
Side effects:
1. Reduce latency in p2q (in prod, right now, it processes a copy of a table, most with priority over newer records).
2. Reduce cpu & mem usage in p2q and postgres (specially in the latter).

Notice this fix is possible as logical replication does not replicate schema (see https://www.postgresql.org/docs/10/logical-replication-restrictions.html).

Sources:
- https://www.postgresql.org/message-id/flat/20170823163151.5dankkw7z72ltmvw%40alap3.anarazel.de#da1e36a289958cb1c38606e541298a6d
- https://www.postgresql.org/message-id/flat/CAODqTUbwxxp87s_jGZeQ6ibii_-5%2BeC5%2B2icvE3F8_w2MjsaGg%40mail.gmail.com#829a7200531074adae3dc6f5d325333d
- https://www.postgresql.org/message-id/flat/20f3de7675f83176253f607b5e199b228406c21c.camel%40cybertec.at
- https://www.postgresql.org/message-id/c6cfe653-f4e0-f623-2dd2-25b3c4be3bd5%40matrix.gatewaynet.com
- https://www.postgresql.org/message-id/84CE67AB46ACDA41B18094177DD0853D212DA8%40ORD2MBX04C.mex05.mlsrvr.com
 

### How to recreate the bug

- first, add some random migration in api with fields that could generate pg_temp. I added the branch `_do-not-merge-p2q-bug` w two of them, you can use it.
- `cd p2q_repo && docker-compose up -d` (recommend to use -d since output could crash console)
- `cd api && bundle exec rake db:environment:set RAILS_ENV=development`
- `bundle exec rake db:import`
- `docker exec -it postgres bash`
  - `su - postgres`
  - `pg_recvlogical --slot=remerge_changes_v2 -d remerge_development --create --plugin=decoderbufs -v -h /var/run/postgresql`
  - here you'll have the wal sender proc after doing the next step
- build and execute p2q 
- `bundle exec rake db:migrate`


### How to recreate the fix

- copy this repo to docker-postgres
- replace docker-postgres/10/Dockerfile by the following

```dockerfile
FROM postgres:10.6

RUN apt-get update -qq \
  && apt-get install -y --force-yes git-core build-essential dh-autoreconf pkg-config wget zlib1g-dev \
  && apt-get clean && rm -rf /var/lib/apt/lists/*

RUN wget https://github.com/google/protobuf/releases/download/v3.1.0/protobuf-cpp-3.1.0.tar.gz \
  && tar -xzf protobuf-cpp-3.1.0.tar.gz && cd protobuf-3.1.0 \
  && ./autogen.sh && ./configure && make && make check && make install && ldconfig \
  && cd .. && rm -rf protobuf-*

RUN git clone --depth 1 --branch v1.2.1 https://github.com/protobuf-c/protobuf-c.git && cd protobuf-c \
  && ./autogen.sh && ./configure && make && make install && ldconfig \
  && cd .. && rm -rf protobuf-c

RUN apt-get update -qq \
  && apt-get install -y --force-yes postgresql-server-dev-10 \
  && apt-get clean && rm -rf /var/lib/apt/lists/*

COPY decoderbufs decoderbufs 

RUN cd decoderbufs && make proto && make && make install && cd ..

COPY config/ scripts/ /docker-entrypoint-initdb.d/
```
- build the image and put the tag in the p2q/docker-compose.yml
- repeat steps defined previously


### Alternative

Sth i find interesting is that removing wal_sender timeout removes the issue. For me, it is clearly a side effect in postgres and could raise another problem.
However, raised a pr with changeset. https://github.com/remerge/chef.new/pull/843. Personally, i don't like that one at all, and this pr is preferable.

[Fix p2q bug causing hanging when temporary tables are processed](https://trello.com/c/NTo6Hdst/5391-fix-p2q-bug-causing-hanging-when-temporary-tables-are-processed)